### PR TITLE
Add check for ~/.cmus folder

### DIFF
--- a/albumshuffle.sh
+++ b/albumshuffle.sh
@@ -22,6 +22,9 @@
 # Matt Collins 02May2016
 
 # set up 'mode' files:
+if [ ! -d ~/.cmus ]; then # to store subsequent values
+	mkdir ~/.cmus
+fi
 if [ ! -f ~/.cmus/mode ]; then # to track whether we're playing an album, or changing
         echo "PLAYING" > ~/.cmus/mode
 fi


### PR DESCRIPTION
If ~/.cmus folder doesn't exist this script will completely break, this change ensures success for users whom do not have a ~/.cmus folder.